### PR TITLE
update react-tools to ~0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "glob": "~3.2.1",
     "mkdirp": "~0.3.5",
-    "react-tools": "~0.3.3",
+    "react-tools": "~0.4.0",
     "through": "~2.3.4"
   }
 }


### PR DESCRIPTION
This uses the latest react-tools version. 
Currently, using grunt-react with react lib v0.4.0 in the browser prints warning messages and prevents internal optimizations.
Tests passes, this is not a major version, it shouldn't break...
