### PR TITLE
Corrected path in two examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ grunt.initConfig({
         ignoreMTime:  false // Default
       },
       files: {
-        'path/to/jsx/templates/dir': 'path/to/output/dir'
+        'path/to/output/dir': 'path/to/jsx/templates/dir'
       }
     },
   },
@@ -122,7 +122,7 @@ grunt.initConfig({
     },
     app: {
       files: {
-        'path/to/jsx/templates/dir': 'path/to/output/dir'
+        'path/to/output/dir': 'path/to/jsx/templates/dir',
       }
     }
   },


### PR DESCRIPTION
Related #7 

The output path comes before the src path in grunt configuration, My grunt tasks were having issues with the settings as described in the examples in README. I got it working by moving Output path before the Source path

```
files: {
  'path/to/output/dir': 'path/to/jsx/templates/dir'
}
```
