### PR TITLE
Updated react-tools dependency to be ~0.5.0, updated plugin version to b...

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-react",
   "description": "Grunt task for compiling Facebook React's .jsx templates into .js",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "homepage": "https://github.com/ericclemmons/grunt-react",
   "author": {
     "name": "Eric Clemmons",
@@ -46,7 +46,7 @@
   "dependencies": {
     "glob": "~3.2.1",
     "mkdirp": "~0.3.5",
-    "react-tools": "~0.4.0",
+    "react-tools": "~0.5.0",
     "through": "~2.3.4"
   }
 }


### PR DESCRIPTION
Updated react-tools dependency to be ~0.5.0.  The current version of react-tools as of this writing is 0.5.1.

Updated plugin version to bt 0.5.0 to make it easier for users to stay with 0.4.x if they choose.

I think this is probably a good idea to match the major/minor version of this plugin with the major/minor version of react-tools, as it makes it more clear in the packages.json what the true dependency is.  It looks to me as though that was already the intent, but I thought I would mentioned it again for anyone else who stumbles across this.
