### PR TITLE
Removed options and use standard file handling from grunt-contrib projects.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,7 @@
  * grunt-react
  * https://github.com/ericclemmons/grunt-react
  *
- * Copyright (c) 2013 Eric Clemmons
+ * Copyright (c) 2013 Eric Clemmons, contributors
  * Licensed under the MIT license.
  */
 
@@ -16,38 +16,60 @@ module.exports = function(grunt) {
       all: [
         'Gruntfile.js',
         'tasks/*.js',
-        '<%= nodeunit.tests %>',
+        '<%= nodeunit.tests %>'
       ],
       options: {
-        jshintrc: '.jshintrc',
+        jshintrc: '.jshintrc'
       },
     },
 
     // Before generating any new files, remove any previously-created files.
     clean: {
-      tests: ['tmp'],
+      tests: ['tmp']
     },
 
     // Configuration to be run (and then tested).
     react: {
-      default_options: {
+      single_js_files: {
         files: {
-          'tmp/default_options': 'test/fixtures',
-        },
-      },
-      extension_option: {
-        options: {
-          extension: 'jsx'
-        },
-        files: {
-          'tmp/extension_option': 'test/fixtures'
+          'tmp/default_options/js/fixture.js': 'test/fixtures/js/fixture.js',
+          'tmp/default_options/js/fixture-jsx.js': 'test/fixtures/js/fixture-jsx.js'
         }
+      },
+      single_jsx_files: {
+        files: {
+          'tmp/extension_option/jsx/fixture.js': 'test/fixtures/jsx/fixture.jsx',
+          'tmp/extension_option/jsx/nested/fixture-js.js': 'test/fixtures/jsx/nested/fixture-js.jsx'
+        }
+      },
+      multiple_jsx_files: {
+        files: {
+          'tmp/extension_option/jsx/fixture-combined.js': ['test/fixtures/jsx/fixture.jsx', 'test/fixtures/jsx/nested/fixture-js.jsx']
+        }
+      },
+      dynamic_mappings: {
+        files: [
+          {
+            expand: true,
+            cwd: 'test/fixtures',
+            src: ['**/*.js'],
+            dest: 'tmp/default_options',
+            ext: '.js'
+          },
+          {
+            expand: true,
+            cwd: 'test/fixtures',
+            src: ['**/*.jsx'],
+            dest: 'tmp/extension_option',
+            ext: '.js'
+          }
+        ]
       }
     },
 
     // Unit tests.
     nodeunit: {
-      tests: ['test/*_test.js'],
+      tests: ['test/*_test.js']
     },
 
   });
@@ -62,7 +84,10 @@ module.exports = function(grunt) {
 
   // Whenever the "test" task is run, first clean the "tmp" dir, then run this
   // plugin's task(s), then test the result.
-  grunt.registerTask('test', ['clean', 'react', 'nodeunit']);
+  grunt.registerTask('testdynamic', ['clean', 'react:dynamic_mappings', 'nodeunit']);
+  grunt.registerTask('testsingle', ['clean', 'react:single_js_files', 'react:single_jsx_files', 'nodeunit']);
+  grunt.registerTask('testarray', ['clean', 'react:multiple_jsx_files', 'nodeunit']);
+  grunt.registerTask('test', ['clean', 'testdynamic', 'testsingle']);
 
   // By default, lint and run all tests.
   grunt.registerTask('default', ['jshint', 'test']);

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # grunt-react [![Build Status](https://travis-ci.org/ericclemmons/grunt-react.png?branch=master)](https://travis-ci.org/ericclemmons/grunt-react)
 
-> Grunt task for compiling [Facebook React](http://facebook.github.io/react/)'s .jsx templates into .js
+> Grunt task for compiling [Facebook React](http://facebook.github.io/react/)'s JSX templates into JavaScript.
 
 It also works great with `grunt-browserify`!
 
@@ -27,15 +27,30 @@ In your project's Gruntfile, add a section named `react` to the data object pass
 ```js
 grunt.initConfig({
   react: {
-    app: {
-      options: {
-        extension:    'js'  // Default,
-        ignoreMTime:  false // Default
-      },
+    single_file_output: {
       files: {
-        'path/to/output/dir': 'path/to/jsx/templates/dir'
+        'path/to/output/dir/output.js': 'path/to/jsx/templates/dir/input.jsx'
       }
     },
+    combined_file_output: {
+      files: {
+        'path/to/output/dir/combined.js': [
+          'path/to/jsx/templates/dir/input1.jsx',
+          'path/to/jsx/templates/dir/input2.jsx'
+        ]
+      }
+    },
+    dynamic_mappings: {
+      files: [
+        {
+          expand: true,
+          cwd: 'path/to/jsx/templates/dir',
+          src: ['**/*.jsx'],
+          dest: 'path/to/output/dir',
+          ext: '.js'
+        }
+      ]
+    }
   },
 })
 ```
@@ -117,14 +132,15 @@ Then, set your Gruntfile to use:
 ```js
 grunt.initConfig({
   react: {
-    options: {
-      extension: 'jsx'
-    },
-    app: {
-      files: {
-        'path/to/output/dir': 'path/to/jsx/templates/dir',
+    files: [
+      {
+        expand: true,
+        cwd: 'path/to/jsx/templates/dir',
+        src: ['**/*.jsx'],
+        dest: 'path/to/output/dir',
+        ext: '.js'
       }
-    }
+    ]
   },
 })
 ```
@@ -149,6 +165,14 @@ var MyComponent = React.createClass({displayName: 'MyComponent',
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 
 ## Release History
+
+### v0.6.0
+
+- Task changes to allow for flexible file options as found in the grunt-contrib projects.
+- Taking hints from grunt-contrib-less to allow for compiling single files separately, dynamic mappings and combining.
+- Removed extension option as this is determined by flexible file matching now.
+- Removed MT time ignoring, this can be easily done with the grunt-newer plugin.
+- Errors are ignored and skipped by default to match how other grunt plugins work.
 
 ### v0.5.0
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-react",
-  "description": "Grunt task for compiling Facebook React's .jsx templates into .js",
-  "version": "0.5.0",
+  "description": "Grunt task for compiling Facebook React's JSX templates into JavaScript",
+  "version": "0.6.0",
   "homepage": "https://github.com/ericclemmons/grunt-react",
   "author": {
     "name": "Eric Clemmons",
@@ -23,7 +23,7 @@
   ],
   "main": "main.js",
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 0.10.0"
   },
   "scripts": {
     "test": "./node_modules/.bin/grunt"
@@ -44,8 +44,6 @@
     "jsx"
   ],
   "dependencies": {
-    "glob": "~3.2.1",
-    "mkdirp": "~0.3.5",
     "react-tools": "~0.5.0",
     "through": "~2.3.4"
   }


### PR DESCRIPTION
The current version of the react plugin is difficult to configure for projects of reasonable complexity.
- If you have a combination of JSX, JS or REACT files, you are only allowed one extension.
- You have to manually set all paths to all your view locations, there is no dynamic option.
- Combing cannot be done with standard file options.
- Using _files_ is misleading when you actually mean _directories_ (this could be anything, but overlaps with the expected usage of _files_).

These updates essentially remove the options and use standard file handling that can be found in many of the grunt-contrib projects. This allows standard path and extension handling with globs, combining and all the dynamic options. This makes it far more flexible in terms of how to find your files and where they are compiled to. It also keeps the handling the same as other plugins making it easier to standardize.

**NB**: These are breaking changes to existing task configs since files patterns are now used instead of directory paths. The best option to reproduce the same functionality is to change the task config to the dynamic version. This is reflected in the reader updates.
