### PR TITLE
Show filename with error if transform fails

### DIFF
--- a/lib/transformers.js
+++ b/lib/transformers.js
@@ -20,7 +20,12 @@ Transformers.browserify = function(file) {
   return through(function(data) {
     source += data;
   }, function() {
-    this.queue(Transformers.source(source));
+    try {
+      this.queue(Transformers.source(source));
+    } catch (e) {
+      console.log('File:', file);
+      throw e;
+    }    
     this.queue(null);
   });
 };


### PR DESCRIPTION
I'm not sure if this is proper way to fix the issue, but browserify core does not trigger 'error' callbacks if transformer fails.
