### PR TITLE
Add source map generating transform

### DIFF
--- a/lib/transformers.js
+++ b/lib/transformers.js
@@ -14,7 +14,7 @@ var Transformers = {};
 
 Transformers.source = transform;
 
-Transformers.browserify = function(file) {
+Transformers.browserify = function(file, includeSourceMap) {
   var source  = '';
 
   return through(function(data) {
@@ -23,7 +23,10 @@ Transformers.browserify = function(file) {
     var result;
 
     try {
-      result = Transformers.source(source);
+      result = Transformers.source(source, {
+        sourceMap: includeSourceMap,
+        sourceFilename: file
+      });
     } catch (error) {
       error.message += ' in "' + file + '"';
 
@@ -33,6 +36,10 @@ Transformers.browserify = function(file) {
     this.queue(result);
     this.queue(null);
   });
+};
+
+Transformers.browserify.withSourceMaps = function(file) {
+  return Transformers.browserify(file, true);
 };
 
 module.exports = Transformers;


### PR DESCRIPTION
Waiting for this https://github.com/facebook/react/pull/910

Usage:

```
grunt.initConfig({
  browserify: {
    options: {
      transform: [ require('grunt-react').browserify.withSourceMaps ],
      debug: true
    },
    app: {
      src: 'index.jsx',
      dest: 'public/index.js'
    }
  }
});
```

Transformed JSX JavaScript output has inline source map comments
appended. Browserify will then combine all these source maps when
bundling.