### PR TITLE
Emit error event for notify

### DIFF
--- a/tasks/react.js
+++ b/tasks/react.js
@@ -54,6 +54,7 @@ module.exports = function(grunt) {
         } catch (e) {
           var error = grunt.log.wordlist(['[react] ' + e], { color: 'red' });
           grunt.log.error(error);
+          grunt.event.emit('react.error', file, e);
           nextFileObj(error);
         }
       }, function () {


### PR DESCRIPTION
Allows to plug in growl or any other notification service.

Important for convenient development.
