### PR TITLE
Throw a proper error when something goes wrong.

### DIFF
--- a/tasks/react.js
+++ b/tasks/react.js
@@ -52,9 +52,7 @@ module.exports = function(grunt) {
           compiled.push(transform(grunt.file.read(file)));
           next();
         } catch (e) {
-          var error = grunt.log.wordlist(['[react] ' + e], { color: 'red' });
-          grunt.log.error(error);
-          nextFileObj(error);
+          grunt.fail.warn(e);
         }
       }, function () {
         grunt.file.write(destFile, compiled.join(grunt.util.normalizelf(grunt.util.linefeed)));


### PR DESCRIPTION
When an error is encountered during compilation, let Grunt know so that it will prevent the execution of dependent tasks.

This change has been around a while and I'd still like to get it into the plugin. All the other Grunt plugins work in this way and our build flow depends on the process failing when something goes wrong.

(Sorry, had to recreate #20 as I moved these changes to a branch)
