### PR TITLE
Mention `harmony` option in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ Default value: `false`
 
 Speed up compilation of JSX files by skipping files not modified since last pass.
 
+#### options.harmony
+Type: `Boolean`
+Default value: `false`
+
+Turns on JS transformations such as ES6 Classes.
+
 - - -
 
 ### Usage Examples


### PR DESCRIPTION
This was added in commit d2de2a2, when we started delegating options to
the transform call. As it's pretty useful, it's probably worth
highlighting in the README.
