### PR TITLE
added support for react-tools transform options

### DIFF
--- a/lib/transformers.js
+++ b/lib/transformers.js
@@ -14,7 +14,7 @@ var Transformers = {};
 
 Transformers.source = transform;
 
-Transformers.browserify = function(file) {
+Transformers.browserify = function(file, options) {
   var source  = '';
 
   return through(function(data) {
@@ -23,7 +23,7 @@ Transformers.browserify = function(file) {
     var result;
 
     try {
-      result = Transformers.source(source);
+      result = Transformers.source(source, options);
     } catch (error) {
       error.message += ' in "' + file + '"';
 


### PR DESCRIPTION
react-tools supports an option object currently only used for `harmony` support.

`require('grunt-react').browserify(code, {harmony: true})`
