### PR TITLE
Bumping react-tools version to 0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "./node_modules/.bin/grunt"
   },
   "dependencies": {
-    "react-tools": "~0.10.0",
+    "react-tools": "~0.11.0",
     "through": "~2.3.4"
   },
   "devDependencies": {


### PR DESCRIPTION
React just got updated to version 0.11.0, so just bumped the version here.
