### PR TITLE
Make the output quieter

### DIFF
--- a/tasks/react.js
+++ b/tasks/react.js
@@ -1,3 +1,4 @@
+
 /*
  * grunt-react
  * https://github.com/ericclemmons/grunt-react
@@ -45,7 +46,7 @@ module.exports = function(grunt) {
 
       var compiled = [];
       grunt.util.async.concatSeries(files, function(file, next) {
-        grunt.log.writeln('[react] Compiling ' + file.cyan + ' --> ' + destFile.cyan);
+        grunt.verbose.writeln('[react] Compiling ' + file.cyan + ' --> ' + destFile.cyan);
 
         try {
           compiled.push(transform(grunt.file.read(file), options));
@@ -57,10 +58,14 @@ module.exports = function(grunt) {
         }
       }, function () {
         grunt.file.write(destFile, compiled.join(grunt.util.normalizelf(grunt.util.linefeed)));
-        grunt.log.writeln('[react] File ' + destFile.cyan + ' created.');
+        grunt.verbose.writeln('[react] File ' + destFile.cyan + ' created.');
         nextFileObj();
       });
 
-    }, done);
+    }, function() {
+      var files = this.files.length.toString();
+      grunt.log.writeln('[react] ' + files.green + ' files compiled');
+      done();
+    }.bind(this));
   });
 };


### PR DESCRIPTION
Only print out every file with verbose tag

For a large project with hundreds of files, printing two lines per file is pretty overwhelming.