### PR TITLE
Added ability to split source maps into separate files.

### DIFF
--- a/tasks/react.js
+++ b/tasks/react.js
@@ -10,6 +10,8 @@
 
 module.exports = function(grunt) {
 
+  var path = require('path');
+
   grunt.registerMultiTask('react', 'Compile Facebook React JSX templates into JavaScript', function() {
     var done = this.async();
 
@@ -57,9 +59,11 @@ module.exports = function(grunt) {
         try {
           var transformed = transform(grunt.file.read(file), options);
           if (options.separateSourceMaps) {
-            compiled.push(transformed.code);
+            var mapfilepath = f.dest.split('/').pop() + '.map';
+            compiled.push(transformed.code + "\n//# sourceMappingURL=" + mapfilepath);
             transformed.sourceMap.file = destFile;
             transformed.sourceMap.sources = [file];
+            transformed.sourceMap.sourceRoot = path.resolve();
             maps.push(JSON.stringify(transformed.sourceMap));
           }
           else {


### PR DESCRIPTION
This makes it easier to feed these source maps into other parts of builds like uglify that, as of present, do not support reading inline source maps.

This is kind of half-baked. The tests pass but I didn't add any for the additional functionality. I'm also working to make sure this works I intend it to as well, but I thought at worst I'd share an idea with you. :smile: :bulb: 

EDIT: Also, it should probably have options for modifying the paths being outputted in the source maps. I didn't / haven't done that yet. Happy to explore this more if it's interesting to you.