### PR TITLE
Fixes #46

### DIFF
--- a/lib/transformers.js
+++ b/lib/transformers.js
@@ -26,6 +26,7 @@ Transformers.browserify = function(file, options) {
 
     try {
       this.queue(Transformers.source(source, options));
+      this.queue(null);
     } catch (error) {
       error.message += ' in "' + file + '"';
 


### PR DESCRIPTION
Without calling `this.queue(null)` the stream is never closed. I can see it was there before 0128961d05be92ba789dcc9dc4a2c9e1731469d3